### PR TITLE
eZPublish provider : Remove unneeded env var to set siteaccess

### DIFF
--- a/src/Boris/Loader/Provider/EzPublish.php
+++ b/src/Boris/Loader/Provider/EzPublish.php
@@ -16,8 +16,6 @@ class EzPublish extends AbstractProvider
     {
         parent::initialize($boris, $dir);
 
-        putenv("EZPUBLISH_SITEACCESS=fr");
-
         require "$dir/ezpublish/bootstrap.php.cache";
         require_once "$dir/ezpublish/EzPublishKernel.php";
 


### PR DESCRIPTION
As pointed by @andrerom, I forgot to clean it up before pull requesting, sorry 'bout that
