### PR TITLE
Update for Current Drupal 8 HEAD

### DIFF
--- a/src/Boris/Loader/Provider/Drupal.php
+++ b/src/Boris/Loader/Provider/Drupal.php
@@ -28,6 +28,9 @@ class Drupal extends AbstractProvider
         );
         $kernel->boot();
 
+        $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
+        \Drupal::getContainer()->set('request', $request);
+
         drupal_bootstrap(DRUPAL_BOOTSTRAP_CODE);
 
         $boris->onStart(function ($worker, $vars) use ($kernel) {


### PR DESCRIPTION
Drupal 8 bootsrap sequence has changed a bit. This is needed to keep the loader working (mimics the current state of drupal_handle_request())
