### PR TITLE
Fix loading for Symfony 3 projects

### DIFF
--- a/src/Boris/Loader/Provider/Symfony2.php
+++ b/src/Boris/Loader/Provider/Symfony2.php
@@ -29,11 +29,14 @@ class Symfony2 extends AbstractProvider
     {
         parent::initialize($boris, $dir);
 
-        if(is_file("$dir/app/bootstrap.php.cache")) {
-            require "$dir/app/bootstrap.php.cache";
-        } else {
+        if(is_file("$dir/app/autoload.php")) {
             require "$dir/app/autoload.php";
         }
+
+        if(is_file("$dir/app/bootstrap.php.cache")) {
+            require "$dir/app/bootstrap.php.cache";
+        }
+		
         require_once "$dir/app/AppKernel.php";
 
         $kernel = new \AppKernel($this->env, $this->debug);


### PR DESCRIPTION
In Symfony 3 the autoload file should always be loaded, and then the
cache file
This still works for Symfony 2 projects as the bootstrap uses
require_once for autoload